### PR TITLE
Catppuccin テーマ統一 & 各種設定改善

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,8 +1,8 @@
 # Theme
-theme = TokyoNight Storm
+theme = Catppuccin Mocha
 
 # Font
-font-family = Menlo
+font-family = JetBrainsMono Nerd Font
 font-size = 14
 font-thicken = true
 
@@ -24,6 +24,9 @@ confirm-close-surface = false
 mouse-hide-while-typing = true
 
 # tmux連携: Ctrl+T prefix対応
+# 起動時に自動でtmuxセッションに入る（既存セッションがあれば復帰）
+command = /opt/homebrew/bin/tmux new-session -A -s main
+
 # Ctrl+TはGhosttyのデフォルトで新規タブなので無効化
 
 # Ctrl+T をtmuxに渡す
@@ -50,7 +53,9 @@ keybind = super+h=text:\x14h
 keybind = super+j=text:\x14j
 keybind = super+k=text:\x14k
 keybind = super+l=text:\x14l
-# Cmd+| → prefix + | (縦分割)
-keybind = super+backslash=text:\x14|
+# Cmd+| or Cmd+¥ → prefix + | (縦分割)
+keybind = super+shift+backslash=text:\x14|
+keybind = super+shift+¥=text:\x14|
+keybind = super+¥=text:\x14|
 # Cmd+- → prefix + - (横分割)
 keybind = super+minus=text:\x14-

--- a/.config/nvim/lua/config/autocmds.lua
+++ b/.config/nvim/lua/config/autocmds.lua
@@ -3,11 +3,17 @@
 local augroup = vim.api.nvim_create_augroup
 local autocmd = vim.api.nvim_create_autocmd
 
--- Open nvim-tree on startup
+-- Open nvim-tree on startup (except for memo files)
 augroup("NvimTreeAutoOpen", { clear = true })
 autocmd("VimEnter", {
   group = "NvimTreeAutoOpen",
   callback = function()
+    -- Skip nvim-tree for memo files
+    local filename = vim.fn.expand("%:p")
+    local memo_dir = vim.fn.expand("~") .. "/memos"
+    if filename:sub(1, #memo_dir) == memo_dir then
+      return
+    end
     require("nvim-tree.api").tree.open()
   end,
 })

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,6 +1,6 @@
-# tmuxを256色表示できるようにする
-set-option -g default-terminal screen-256color
-set -g terminal-overrides 'xterm:colors=256'
+# tmuxを256色表示できるようにする (true color対応)
+set-option -g default-terminal "tmux-256color"
+set-option -sa terminal-overrides ",xterm*:Tc"
 
 # prefixキーをC-tに変更
 set -g prefix C-t
@@ -8,31 +8,8 @@ set -g prefix C-t
 # C-bのキーバインドを解除
 unbind C-b
 
-# ステータスバーをトップに配置する
+# ステータスバーをボトムに配置
 set-option -g status-position bottom
-
-# 左右のステータスバーの長さを決定する
-set-option -g status-left-length 90
-set-option -g status-right-length 90
-
-# #P => ペイン番号
-# 最左に表示
-set-option -g status-left '#H:[#P]'
-
-# 現在時刻を最右に表示
-set-option -g status-right '[%Y-%m-%d(%a) %H:%M]'
-
-# ステータスバーを1秒毎に描画し直す
-set-option -g status-interval 1
-
-# センタライズ（主にウィンドウ番号など）
-set-option -g status-justify centre
-
-# ステータスバーの色を設定する
-set-option -g status-bg "colour238"
-
-# status line の文字色を指定する。
-set-option -g status-fg "colour255"
 
 # vimのキーバインドでペインを移動する
 bind h select-pane -L
@@ -55,6 +32,10 @@ bind - split-window -v
 # 番号基準値を変更
 set-option -g base-index 1
 
+# ウィンドウ名をカレントディレクトリ名に自動設定
+set-option -g automatic-rename on
+set-option -g automatic-rename-format '#{b:pane_current_path}'
+
 # マウス操作を有効にする
 set-option -g mouse on
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'copy-mode -e'"
@@ -71,3 +52,39 @@ bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "pbcopy"
 # popup でghq/gwq呼び出し（tmux 3.2+）
 bind g display-popup -E "zsh -ic 'ghq-tmux'"
 bind w display-popup -E "zsh -ic 'gwq-tmux'"
+
+# ===========================================
+# Plugins (TPM)
+# ===========================================
+
+# Catppuccin theme (Ghosttyと統一)
+set -g @plugin 'catppuccin/tmux#v2.1.3'
+set -g @catppuccin_flavor 'mocha'
+set -g @catppuccin_window_status_style 'rounded'
+
+# tmux-battery (Catppuccin のバッテリーモジュールに必要)
+set -g @plugin 'tmux-plugins/tmux-battery'
+
+# TPM (Tmux Plugin Manager)
+set -g @plugin 'tmux-plugins/tpm'
+run-shell "PATH=/opt/homebrew/bin:$PATH $HOME/.tmux/plugins/tpm/tpm"
+
+# Catppuccin battery モジュールの変数を直接シェルコマンドで上書き
+# (tmux-battery の #{battery_icon} は tmux 変数ではなく文字列置換用プレースホルダーのため、
+#  #{l:#{battery_icon}} では動作しない。直接シェルコマンドを呼び出す)
+# IMPORTANT: catppuccin.tmux の「前」に設定する必要がある
+# (icon は -F フラグで即座に展開されるため、後から上書きしても手遅れ)
+set -g @catppuccin_battery_icon "#(~/.tmux/plugins/tmux-battery/scripts/battery_icon.sh) "
+set -g @catppuccin_battery_text " #(~/.tmux/plugins/tmux-battery/scripts/battery_percentage.sh)"
+
+# Catppuccin テーマをロード (status module 設定の前に必要)
+# PATH を設定して /usr/bin/env bash が動作するようにする
+run-shell "PATH=/opt/homebrew/bin:$PATH ~/.tmux/plugins/tmux/catppuccin.tmux"
+
+# Status line 設定 (Catppuccin v2 形式)
+set -g status-right-length 100
+set -g status-left-length 100
+set -g status-left ""
+set -g status-right "#{E:@catppuccin_status_session}"
+set -ga status-right "#{E:@catppuccin_status_battery}"
+set -ga status-right "#{E:@catppuccin_status_date_time}"


### PR DESCRIPTION
## Summary
- tmux, Ghostty を Catppuccin Mocha テーマに統一
- tmux の True color 対応改善 + TPM プラグイン導入
- Ghostty の tmux 自動起動設定追加
- Neovim で memo ファイル編集時の nvim-tree 自動オープンを無効化

## Changes
- `.tmux.conf`: Catppuccin テーマ、True color 対応、バッテリー表示
- `.config/ghostty/config`: Catppuccin テーマ、JetBrainsMono フォント、tmux 自動起動
- `.config/nvim/lua/config/autocmds.lua`: memo ファイル除外ロジック追加

## Test plan
- [x] tmux でステータスバーが Catppuccin テーマで表示される
- [x] Ghostty 起動時に tmux セッションが自動で開始/アタッチされる
- [x] `memo` コマンドで作成したファイルを開く際、nvim-tree が開かない

🤖 Generated with [Claude Code](https://claude.ai/code)