### PR TITLE
:wrench: aliases.shを対話シェル限定にガード

### DIFF
--- a/.config/shell/aliases.sh
+++ b/.config/shell/aliases.sh
@@ -1,5 +1,9 @@
 # aliases.sh - Modern CLI tool aliases
 
+# Interactive-only: non-interactive shells (Claude Code's Bash tool, CI scripts)
+# should see the real commands with their original option syntax.
+[[ -o interactive ]] || return 0
+
 alias vi=nvim
 alias vim=nvim
 alias cat='bat --paging=never'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ dotfiles/
 
 **Modern CLI Tool Aliases**
 - All defined in `.config/shell/aliases.sh` - traditional commands aliased to modern alternatives (cat->bat, ls->eza, grep->rg, find->fd, ps->procs, du->dust, df->duf, sed->sd, top->btop, http->xh, vi/vim->nvim)
+- Guarded with `[[ -o interactive ]] || return 0` at the top — non-interactive shells (Claude Code's Bash tool, CI scripts) see the real commands, so `grep -P`, `find -name`, `ps aux` etc. behave as documented
 - Important: SDKMAN init in `.config/shell/platform.sh` temporarily unaliases `find` to avoid conflicts, then restores it
 
 ## Git Commit Conventions
@@ -231,7 +232,7 @@ Note: The existing commit history uses `:memo:` for documentation, not `:books:`
 - `.zshrc` is a ~26-line loader that sources oh-my-zsh and all shell modules
 - Each module is self-contained with its own functions and keybindings
 - Module load order matters: `env.sh` first (PATH/tools), `platform.sh` last (SDKMAN needs aliases)
-- ZLE widgets (`zle -N`, `bindkey`) are guarded with `[[ -o interactive ]]` so modules can be sourced from non-interactive scripts
+- ZLE widgets (`zle -N`, `bindkey`) and `aliases.sh` are guarded with `[[ -o interactive ]]` so modules can be sourced from non-interactive scripts (e.g. Claude Code's Bash tool) without side effects
 
 **tmux Popup Optimization**
 - tmux popup bindings (prefix+g/w/s) use standalone scripts in `.config/shell/bin/` instead of `zsh -ic`


### PR DESCRIPTION
## Summary
- `.config/shell/aliases.sh` 先頭に `[[ -o interactive ]] || return 0` を追加し、非対話シェル（Claude Code の Bash ツール、CI スクリプト）では alias が展開されないようにした
- Claude が従来コマンドのオプション（`grep -P`, `find -name`, `ps aux` 等）を使った際、モダン版（rg/fd/procs）に置き換わってオプションエラーになる事象を根絶
- ZLE widget の既存ガードパターン（`ghq-tmux.sh:4`, `gwq-tmux.sh:4`）と一貫した書き方
- `CLAUDE.md` のガード方針と alias セクションを更新

## Behavior
- 対話ターミナル: 従来通り `cat→bat`, `ls→eza`, `grep→rg` などが有効
- Claude Code の Bash / CI / `zsh -c` など非対話コンテキスト: real command が使われる

## Test plan
- [ ] 新規ターミナルで `alias cat`, `alias lg`, `alias ll` が定義通り返ること
- [ ] `zsh -c 'source ~/.config/shell/aliases.sh; alias'` の出力が空であること
- [ ] `zsh -ic 'alias cat'` が `cat='bat --paging=never'` を返すこと
- [ ] Claude Code の Bash ツールから `grep -rn pattern .`, `find . -name '*.sh'`, `ps aux | head` が成功すること
- [ ] `./scripts/validate.sh` が通ること

https://claude.ai/code/session_01VBk9EjzfBHb1rwWDPhzhwo