### PR TITLE
:sparkles: Hammerspoon連携で仮想デスクトップ越しのウィンドウ前面化に対応

### DIFF
--- a/.config/claude/bin/claude-status
+++ b/.config/claude/bin/claude-status
@@ -62,21 +62,29 @@ rows() {
     ' "$@" 2>/dev/null
 }
 
-# 対象セッションを既に表示しているtmuxクライアント (=別のGhosttyウィンドウ) が
-# あれば、そのOSウィンドウを前面化する。tmuxがウィンドウタイトルを
-# "セッション名: ディレクトリ" に設定している (set-titles-string) ことを利用して
-# System Events でタイトル前方一致のGhosttyウィンドウをAXRaiseする。
-# 初回はmacOSのオートメーション許可ダイアログが出る。
+# 指定セッションを表示しているGhosttyウィンドウをOSレベルで前面化する。
+# tmuxがウィンドウタイトルを "セッション名: ディレクトリ" に設定している
+# (set-titles-string) ことを利用したタイトル前方一致検索。
+# 1. Hammerspoon (hs CLI) があれば hs.spaces で仮想デスクトップ (Space) 越しに
+#    フォーカス (.config/hammerspoon/init.lua の claudeFocusGhosttyWindow)
+# 2. なければ System Events でAXRaise (現在のSpaceのウィンドウしか発見できない)
+# 初回はmacOSのオートメーション/アクセシビリティ許可ダイアログが出る。
 # 無効化: CLAUDE_JUMP_FOCUS_DISABLED=1
-focus_client_window() {
-    local tsess=$1
+raise_window_for_session() {
+    local sess=$1
+    [ -z "$sess" ] && return 1
     [ "${CLAUDE_JUMP_FOCUS_DISABLED:-0}" = "1" ] && return 1
+    local prefix="${sess}: "
+    if command -v hs >/dev/null 2>&1; then
+        local esc out
+        esc=$(printf '%s' "$prefix" | sed 's/\\/\\\\/g; s/"/\\"/g')
+        out=$(hs -c "claudeFocusGhosttyWindow(\"$esc\")" 2>/dev/null)
+        [ "$out" = "true" ] && return 0
+    fi
     command -v osascript >/dev/null 2>&1 || return 1
-    # 対象セッションにアタッチ中のクライアントがなければ対象外
-    tmux list-clients -F '#{client_session}' 2>/dev/null | grep -qx "$tsess" || return 1
-    osascript - "$tsess" <<'APPLESCRIPT' >/dev/null 2>&1
+    osascript - "$prefix" <<'APPLESCRIPT' >/dev/null 2>&1
 on run argv
-    set target to (item 1 of argv) & ": "
+    set target to item 1 of argv
     tell application "System Events"
         tell process "Ghostty"
             repeat with w in windows
@@ -120,7 +128,7 @@ find_sibling_client() {
         [ -n "$cpath" ] || continue
         croot=$(git -C "$cpath" rev-parse --show-toplevel 2>/dev/null)
         if [ -n "$croot" ] && [ "$croot" = "$troot" ]; then
-            printf '%s' "$client"
+            printf '%s %s' "$client" "$csess"
             return 0
         fi
     done <<EOF
@@ -130,9 +138,11 @@ EOF
 }
 
 # 指定のtmux位置に切り替える (セッション → window → pane の順で絞り込み)
-# 1. 対象セッションを表示中のGhosttyウィンドウがあれば前面化
-# 2. 同じworktreeの別セッションを表示中のウィンドウがあれば、
-#    そのウィンドウ側のクライアントを切り替えて前面化
+# 1. 対象セッションを表示中のGhosttyウィンドウがあれば前面化。
+#    前面化できない場合 (別Space + Hammerspoonなし等) は無反応にせず
+#    現在のクライアントを切り替える
+# 2. 同じworktreeの別セッションを表示中のウィンドウがあれば、先にそのウィンドウを
+#    前面化してから (タイトルが正確なうちに) そのクライアントを切り替える
 # 3. どちらもなければ現在のクライアントをswitch-client
 jump_to() {
     local tsess=$1 twin=$2 tpane=$3
@@ -140,17 +150,18 @@ jump_to() {
     # window/pane選択はセッション単位の状態なので、どのクライアントで表示していても効く
     [ -n "$twin" ] && tmux select-window -t "${tsess}:${twin}" 2>/dev/null
     [ -n "$tpane" ] && tmux select-pane -t "$tpane" 2>/dev/null
-    if focus_client_window "$tsess"; then
+    if tmux list-clients -F '#{client_session}' 2>/dev/null | grep -qx "$tsess"; then
+        raise_window_for_session "$tsess" && return 0
+        tmux switch-client -t "$tsess" 2>/dev/null || return 1
         return 0
     fi
-    local sib
-    sib=$(find_sibling_client "$tsess")
-    if [ -n "$sib" ] && tmux switch-client -c "$sib" -t "$tsess" 2>/dev/null; then
-        # ウィンドウタイトルが新セッション名に更新されるのを待って前面化
-        # (前面化に失敗しても切り替え自体は完了しているので成功扱い)
-        sleep 0.2
-        focus_client_window "$tsess" || { sleep 0.3; focus_client_window "$tsess"; }
-        return 0
+    local sib scsess
+    read -r sib scsess <<EOF
+$(find_sibling_client "$tsess")
+EOF
+    if [ -n "$sib" ]; then
+        raise_window_for_session "$scsess"
+        tmux switch-client -c "$sib" -t "$tsess" 2>/dev/null && return 0
     fi
     tmux switch-client -t "$tsess" 2>/dev/null || return 1
     return 0

--- a/.config/hammerspoon/init.lua
+++ b/.config/hammerspoon/init.lua
@@ -1,0 +1,36 @@
+-- Hammerspoon設定
+-- 用途: claude-status のジャンプ機能で、別の仮想デスクトップ (Space) にある
+-- GhosttyウィンドウへSpace切り替え込みでフォーカスを移す。
+-- macOSのアクセシビリティAPI (System Events) は現在のSpaceのウィンドウしか
+-- 列挙できないため、hs.spaces を使うHammerspoonが必要になる。
+
+-- hs CLI (claude-statusから `hs -c` で呼び出すためのIPC)
+require("hs.ipc")
+if not hs.ipc.cliStatus("/opt/homebrew") then
+    hs.ipc.cliInstall("/opt/homebrew")
+end
+
+-- 全Spaceを対象にGhosttyのウィンドウを追跡するフィルタ
+local ghosttyFilter = hs.window.filter.new(false)
+    :setAppFilter("Ghostty", {})
+    :setCurrentSpace(nil)
+
+-- タイトル前方一致でGhosttyウィンドウを探し、必要ならSpaceを切り替えてフォーカスする。
+-- tmuxがウィンドウタイトルを「セッション名: ディレクトリ」に設定している前提。
+-- claude-status から `hs -c 'claudeFocusGhosttyWindow("セッション名: ")'` で呼ばれ、
+-- 見つかれば true、なければ false を返す。
+function claudeFocusGhosttyWindow(titlePrefix)
+    for _, win in ipairs(ghosttyFilter:getWindows()) do
+        local title = win:title() or ""
+        if title:sub(1, #titlePrefix) == titlePrefix then
+            local ok, spaces = pcall(hs.spaces.windowSpaces, win)
+            if ok and spaces and #spaces > 0
+                and spaces[1] ~= hs.spaces.focusedSpace() then
+                pcall(hs.spaces.gotoSpace, spaces[1])
+            end
+            win:focus()
+            return true
+        end
+    end
+    return false
+end

--- a/Brewfile
+++ b/Brewfile
@@ -140,6 +140,7 @@ cask "android-studio"
 cask "gcloud-cli"
 cask "ghostty"
 cask "google-chrome"
+cask "hammerspoon"   # Space越しウィンドウフォーカス (claude-status jump)
 cask "intellij-idea-ce"
 cask "microsoft-word"
 cask "rancher"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Repository clones via `gh repo clone` will automatically use the correct Git ide
 - `.config/atuin/` - Atuin shell history sync config
 - `.config/ghostty/` - Ghostty terminal emulator config (catppuccin theme, tmux integration keybindings: Cmd+T=prefix, Cmd+N=new window, Cmd+W=close pane, Cmd+1-9=window switch, Cmd+H/J/K/L=pane nav, Cmd+\=vsplit, Cmd+-=hsplit)
 - `.config/gwq/config.toml` - gwq configuration (basedir: `~/repos`)
+- `.config/hammerspoon/init.lua` - Hammerspoon config (Space-crossing window focus for claude-status jump; symlinked to both `~/.config/hammerspoon` and `~/.hammerspoon`)
 - `.config/lazygit/config.yml` - lazygit custom commands (gh PR integration: list, view, checkout, create, diff)
 
 **Package Management**
@@ -184,7 +185,7 @@ dotfiles/
 - Claude Code hooks (`.config/claude/hooks/update-state.sh`) record each session's state (working/waiting/idle) plus its tmux session/window/pane to `~/.local/state/claude/sessions/*.json`
 - `.config/claude/bin/claude-status` renders the state: `bar` (status-right counts, refreshed instantly via `tmux refresh-client -S` from the hook), `watch` (sidebar pane loop), `sessions` (per-tmux-session glyphs for fzf), `jump` (switch to highest-priority session)
 - `prefix+a` toggles a sidebar pane (`.config/shell/bin/claude-sidebar-toggle`) listing all Claude sessions with state glyph (🔔 waiting for input / ⚙ working / ✓ idle), age, `window.pane` location (distinguishes multiple Claude instances inside one tmux session), and last prompt/notification; keys `1-9` jump to that session's pane, `q` closes it
-- `prefix+u` jumps to the highest-priority Claude session (waiting > working > idle). Target window resolution: (1) a client already attached to the target session → raise that OS window via System Events title matching; (2) a client showing another session of the same worktree (`git rev-parse --show-toplevel` match) → switch that client to the target session and raise it (supports multiple tmux sessions per worktree); (3) otherwise switch the current client. Disable window raising with `CLAUDE_JUMP_FOCUS_DISABLED=1`
+- `prefix+u` jumps to the highest-priority Claude session (waiting > working > idle). Target window resolution: (1) a client already attached to the target session → raise that OS window (falls back to switching the current client if raising fails); (2) a client showing another session of the same worktree (`git rev-parse --show-toplevel` match) → raise that window first, then switch that client to the target session (supports multiple tmux sessions per worktree); (3) otherwise switch the current client. Window raising prefers Hammerspoon (`hs` CLI + `.config/hammerspoon/init.lua`) which crosses virtual desktops (Spaces) via `hs.spaces`; without it, System Events AXRaise is used (current Space only — the accessibility API cannot enumerate windows on other Spaces). Disable with `CLAUDE_JUMP_FOCUS_DISABLED=1`
 - `tmux-session-fzf` (prefix+s) shows the same glyphs next to session names
 - The Notification hook also posts to macOS Notification Center (injection-safe via `osascript` argv; disable with `CLAUDE_NOTIFY_DISABLED=1`)
 - Stale state files (>24h) are cleaned automatically; state detection is hook-based (exact), unlike herdr's screen-scraping heuristics

--- a/README.md
+++ b/README.md
@@ -183,11 +183,16 @@ Claude Codeのhooksが各セッションの状態を `~/.local/state/claude/sess
 - **ステータスバー**: 状態別カウントを常時表示。hooks経由で即時更新
 - **サイドバー** (`prefix+a`): 全Claudeセッションの状態・経過時間・最後のプロンプト/通知を一覧表示。同一tmuxセッション内に複数のClaudeがいる場合も `セッション名 window.pane` 表記で区別できる。開くとフォーカスがサイドバーに移り、数字キー `1-9` でそのClaudeのpaneにジャンプ、`q` または再度 `prefix+a` で閉じる
 - **ジャンプ** (`prefix+u`): 最優先のClaudeセッション (🔔入力待ち優先) に一発で切り替え。サイドバーの数字キージャンプも同様。切り替え先の決め方:
-  1. 対象セッションを表示中のGhosttyウィンドウがあればそのウィンドウを前面化
+  1. 対象セッションを表示中のGhosttyウィンドウがあればそのウィンドウを前面化 (前面化できないときは現在のウィンドウ内で切り替え)
   2. なければ、同じリポジトリ (worktree) の別セッションを表示中のウィンドウを探し、そのウィンドウ側をセッション切り替えして前面化 (1 worktree内に複数tmuxセッションを作る運用向け)
   3. どちらもなければ現在のウィンドウ内でswitch-client
 
   前面化は初回にmacOSのオートメーション許可が必要。`CLAUDE_JUMP_FOCUS_DISABLED=1` で無効化
+
+  **仮想デスクトップ (Space) 対応**: macOSのアクセシビリティAPIは現在のSpaceのウィンドウしか列挙できないため、別デスクトップへの前面化には**Hammerspoonが必要** (`brew install --cask hammerspoon`、Brewfileに含まれる)。セットアップ:
+  1. Hammerspoon.appを起動し、アクセシビリティ権限を許可、「Launch at login」を有効化
+  2. 設定は `~/.hammerspoon` (dotfilesの `.config/hammerspoon/` へのsymlink) が自動で読まれ、`hs` CLIも自動インストールされる
+  3. Hammerspoonがない場合は従来のSystem Events方式 (同一Space内のみ) に自動フォールバック
 - **セッション切替** (`prefix+s`): fzfの一覧に状態グリフを表示
 - **macOS通知**: Claudeが入力待ちになると通知センターに表示 (`CLAUDE_NOTIFY_DISABLED=1` で無効化)
 

--- a/scripts/setup/symlinks.sh
+++ b/scripts/setup/symlinks.sh
@@ -18,6 +18,7 @@ CONFIG_DIRS=(
     git
     gitmux
     gwq
+    hammerspoon
     lazygit
     mise
     nvim
@@ -70,6 +71,12 @@ setup_symlinks() {
     if [ -f "$DOTFILES_DIR/.config/claude/settings.json" ]; then
         mkdir -p "$HOME/.claude"
         safe_symlink "$DOTFILES_DIR/.config/claude/settings.json" "$HOME/.claude/settings.json"
+    fi
+
+    # Hammerspoon reads ~/.hammerspoon/init.lua (XDG非対応バージョンがあるため
+    # ~/.config/hammerspoon に加えて ~/.hammerspoon もリンクする)
+    if [ -d "$DOTFILES_DIR/.config/hammerspoon" ]; then
+        safe_symlink "$DOTFILES_DIR/.config/hammerspoon" "$HOME/.hammerspoon"
     fi
 
     # SSH config (personal + Include ~/.ssh/config.local for per-machine/work entries)


### PR DESCRIPTION
## 概要

仮想デスクトップ (Space) をまたぐジャンプが機能しない問題への対応 (実機確認済みの制限)。

macOSのアクセシビリティAPI (System Events) は**現在のSpaceにあるウィンドウしか列挙できない**ため、別デスクトップのGhosttyウィンドウをタイトル検索で発見できず、Space越しの前面化が原理的に不可能だった。`hs.spaces` (Hammerspoon) を使って解決する。

## 変更内容

### Hammerspoon連携 (`.config/hammerspoon/init.lua` 新規)

- `hs.window.filter` (全Space対象) でGhosttyウィンドウをタイトル前方一致検索
- 対象が別Spaceにあれば `hs.spaces.gotoSpace` でデスクトップを切り替えてからフォーカス
- `hs.ipc` で `hs` CLIを自動インストールし、claude-statusから `hs -c` で呼び出す

### claude-status

- 前面化を `raise_window_for_session()` に集約: `hs` CLIがあればHammerspoon経由 (Space越し対応)、なければ従来のSystem Events (同一Spaceのみ) に自動フォールバック
- **前面化に失敗しても無反応にしない**: 現在のクライアントを切り替えるフォールバックを追加 (従来はSpace越しジャンプが見かけ上no-opになるケースがあった)
- 同一worktreeクライアント切り替えは「前面化 → switch-client」の順に変更し、タイトルが正確なうちにウィンドウを特定 (旧実装のsleepリトライを除去)

### セットアップ

- Brewfileに `cask "hammerspoon"` を追加
- symlinks.sh: `~/.config/hammerspoon` と `~/.hammerspoon` の両方にリンク (XDG非対応バージョン対策)

## マージ後のセットアップ手順

1. `git pull && brew bundle` (または `brew install --cask hammerspoon`)
2. `./init.sh` でsymlink作成 (または手動: `ln -s ~/repos/github.com/ishihama/dotfiles/.config/hammerspoon ~/.hammerspoon`)
3. Hammerspoon.appを起動 → アクセシビリティ権限を許可 → 「Launch at login」を有効化

## テスト

- 実tmux (2リポジトリ/3セッション/2クライアント) でジャンプ3経路 (sibling切り替え・アタッチ済み・フォールバック) を検証
- `bash -n` 構文チェック
- macOS実機での要確認: 別デスクトップのウィンドウへの `prefix+u` ジャンプでデスクトップごと切り替わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAvBeGJmpUzrhbSoCcRzyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAvBeGJmpUzrhbSoCcRzyC)_