### PR TITLE
:wrench: android-platform-tools をcask管理から除外 (brew bundle恒常失敗の根本対応)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -135,7 +135,11 @@ brew "tldr"          # simplified man pages
 # ===========================================
 # Casks (GUI Applications)
 # ===========================================
-cask "android-platform-tools"
+# android-platform-tools はcask管理しない:
+# Googleが同一URLでファイルを差し替えるたびにchecksum不一致でbrew bundle全体が
+# 失敗するため。adb等はAndroid StudioのSDK Manager (Settings > Languages &
+# Frameworks > Android SDK > SDK Tools > Android SDK Platform-Tools) で管理する。
+# PATHは env.sh が ~/Library/Android/sdk/platform-tools を通している。
 cask "android-studio"
 cask "gcloud-cli"
 cask "ghostty"


### PR DESCRIPTION
## 概要

`brew bundle` が `android-platform-tools` のchecksum不一致で全体失敗する問題の根本対応。

```
Error: Cask reports different checksum: 7d009f4fb1...
       SHA-256 checksum of downloaded file: ee39ad5967...
```

## 原因

- Googleは platform-tools を**同一URLのままファイル差し替え**で再リリースするため、homebrew-cask定義のSHA-256が定期的に実物と食い違う (cask側が追従するまで数日壊れたままになる、再発性の既知問題)
- 現行の `brew bundle` は1つのfetch失敗で残り全パッケージも失敗扱いになるため、このcask1つがBrewfile全体を巻き添えにしていた

## 対応

`cask "android-platform-tools"` をBrewfileから削除し、理由をコメントで記載。

**adbが使えなくなることはない**: `env.sh` が既に `~/Library/Android/sdk/platform-tools` (Android StudioのSDK Manager管理領域) をPATHに通しており、cask版 (`/opt/homebrew/bin`) より優先されるため、cask版は実際には使われていなかった。今後はSDK Manager (Settings > Android SDK > SDK Tools > Android SDK Platform-Tools) で更新する。

## マージ後の手元作業 (任意)

```bash
brew uninstall --cask android-platform-tools   # 使われていなかったcask版の掃除
brew bundle                                     # 全体が通ることを確認
```

SDK Managerでplatform-toolsが未インストールの場合はAndroid Studioから入れる (通常はAndroid開発セットアップ済みなら入っている)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAvBeGJmpUzrhbSoCcRzyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAvBeGJmpUzrhbSoCcRzyC)_