### PR TITLE
:bug: Hammerspoonの別Spaceウィンドウ検出を修正

### DIFF
--- a/.config/hammerspoon/init.lua
+++ b/.config/hammerspoon/init.lua
@@ -10,27 +10,71 @@ if not hs.ipc.cliStatus("/opt/homebrew") then
     hs.ipc.cliInstall("/opt/homebrew")
 end
 
--- 全Spaceを対象にGhosttyのウィンドウを追跡するフィルタ
+-- 全Spaceを対象にGhosttyのウィンドウを追跡するフィルタ。
+-- 重要: 購読 (subscribe) しないと受動的スキャンになり現在のSpaceの
+-- ウィンドウしか見えない。空コールバックで常時追跡モードにすることで、
+-- 一度でも表示したSpaceのウィンドウをキャッシュし続ける。
 local ghosttyFilter = hs.window.filter.new(false)
     :setAppFilter("Ghostty", {})
     :setCurrentSpace(nil)
+ghosttyFilter:subscribe(hs.window.filter.windowCreated, function() end)
 
 -- タイトル前方一致でGhosttyウィンドウを探し、必要ならSpaceを切り替えてフォーカスする。
 -- tmuxがウィンドウタイトルを「セッション名: ディレクトリ」に設定している前提。
 -- claude-status から `hs -c 'claudeFocusGhosttyWindow("セッション名: ")'` で呼ばれ、
 -- 見つかれば true、なければ false を返す。
 function claudeFocusGhosttyWindow(titlePrefix)
+    -- フィルタのキャッシュ (全Space) とAXの直接列挙 (現在のSpace) を統合して検索
+    local candidates = {}
+    local seen = {}
     for _, win in ipairs(ghosttyFilter:getWindows()) do
+        candidates[#candidates + 1] = win
+        local id = win:id()
+        if id then seen[id] = true end
+    end
+    local ghostty = hs.application.get("Ghostty")
+    if ghostty then
+        for _, win in ipairs(ghostty:allWindows()) do
+            local id = win:id()
+            if not (id and seen[id]) then
+                candidates[#candidates + 1] = win
+            end
+        end
+    end
+    for _, win in ipairs(candidates) do
         local title = win:title() or ""
         if title:sub(1, #titlePrefix) == titlePrefix then
             local ok, spaces = pcall(hs.spaces.windowSpaces, win)
             if ok and spaces and #spaces > 0
                 and spaces[1] ~= hs.spaces.focusedSpace() then
                 pcall(hs.spaces.gotoSpace, spaces[1])
+                -- Space切り替えアニメーション中のfocus失敗を避ける
+                hs.timer.usleep(300000)
             end
             win:focus()
             return true
         end
     end
     return false
+end
+
+-- デバッグ用: Hammerspoonから見えているGhosttyウィンドウの一覧を返す
+-- `hs -c 'claudeListGhosttyWindows()'` で確認する
+function claudeListGhosttyWindows()
+    local out = {}
+    for _, win in ipairs(ghosttyFilter:getWindows()) do
+        local _, spaces = pcall(hs.spaces.windowSpaces, win)
+        out[#out + 1] = string.format("[filter] spaces=%s title=%s",
+            hs.inspect(spaces or {}), win:title() or "(no title)")
+    end
+    local ghostty = hs.application.get("Ghostty")
+    if ghostty then
+        for _, win in ipairs(ghostty:allWindows()) do
+            local _, spaces = pcall(hs.spaces.windowSpaces, win)
+            out[#out + 1] = string.format("[ax]     spaces=%s title=%s",
+                hs.inspect(spaces or {}), win:title() or "(no title)")
+        end
+    end
+    out[#out + 1] = "focusedSpace=" .. tostring(hs.spaces.focusedSpace())
+    return table.concat(out, "\n")
 end


### PR DESCRIPTION
## 概要

Hammerspoon導入後も仮想デスクトップを越えてウィンドウが切り替わらない問題の修正。

## 原因

`hs.window.filter` は**購読 (subscribe) していないと受動的スキャン**になり、`getWindows()` を呼んだ時点のAX列挙 = 現在のSpaceのウィンドウしか返さないことがある。`setCurrentSpace(nil)` を指定していても、常時追跡が動いていなければ別Spaceのウィンドウはキャッシュされない。

## 変更内容

- 空コールバックでフィルタを購読し、常時追跡モードに変更 (一度でも表示したSpaceのウィンドウをキャッシュし続ける)
- フィルタのキャッシュと `hs.application:allWindows()` (AX直接列挙) を統合して検索し、取りこぼしを削減
- `hs.spaces.gotoSpace` 直後のfocus失敗を避ける300ms待機を追加
- `win:id()` がnilを返すウィンドウでの実行時エラーを防止
- デバッグ用 `claudeListGhosttyWindows()` を追加: `hs -c 'claudeListGhosttyWindows()'` で見えているウィンドウとSpace一覧を確認できる

## 既知の制約

Hammerspoon起動後に一度も表示していないSpaceのウィンドウは追跡できないことがある (macOS AXの制限)。各デスクトップを一巡すれば以降はキャッシュされる。

## マージ後の確認手順

```bash
git pull
hs -c 'hs.reload()'            # 設定リロード (メニューのReload Configでも可)
# 各デスクトップを一巡してから:
hs -c 'claudeListGhosttyWindows()'   # 全ウィンドウがspaces付きで見えるか
hs -c 'claudeFocusGhosttyWindow("<別デスクトップのセッション名>: ")'  # trueが返り切り替わるか
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAvBeGJmpUzrhbSoCcRzyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAvBeGJmpUzrhbSoCcRzyC)_